### PR TITLE
Add GitHub Actions workflow to close inactive issues automatically

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,26 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: '33 1 * * *'
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          stale-issue-message:
+            'This issue is stale because it has been open for 30 days with no
+            activity.'
+          close-issue-message:
+            'This issue was closed because it has been inactive for 14 days
+            since being marked as stale.'
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implement a scheduled workflow that marks issues as stale after 30 days of inactivity and closes them after an additional 14 days. This helps maintain a clean issue tracker.