### PR TITLE
Added support for Github enterprise on-premise

### DIFF
--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -19,7 +19,11 @@ export const fetchWorkflowResults = async (
   maxTry = 10
 ): Promise<WorkflowResults> => {
   const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN // read environment variable for testing
-  const octokit = new Octokit({ auth: token })
+  const serverUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const octokit = new Octokit({
+  baseUrl: serverUrl,
+  auth: token
+  });
   const workflowRunContext = getWorkflowRunContext(github.context)
   try {
     // A workflow sometime has not completed in spite of trigger of workflow completed event.


### PR DESCRIPTION
When the action Github enterprise on-premise Octokit is getting the api URL wrongly