### PR TITLE
Add GitHub Actions workflow for E2E testing telemetry

### DIFF
--- a/.github/workflows/run-action.yml
+++ b/.github/workflows/run-action.yml
@@ -1,0 +1,23 @@
+name: run actions for E2E testing
+
+on:
+  workflow_run:
+    workflows:
+      - main
+    types:
+      - completed
+
+jobs:
+  send-telemetry:
+    name: Send CI Telemetry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run
+        id: run
+        uses: paper2/github-actions-opentelemetry@main
+        env:
+          OTEL_EXPORTER_OTLP_ENDPOINT:
+            ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+          OTEL_SERVICE_NAME: github-actions-opentelemetry
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce a workflow to send telemetry data for end-to-end testing upon completion of the main workflow.