### PR TITLE
Add ignore stale label

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -18,6 +18,7 @@ jobs:
           stale-issue-message:
             'This issue is stale because it has been open for 30 days with no
             activity.'
+          exempt-issue-labels: 'not-stale'
           close-issue-message:
             'This issue was closed because it has been inactive for 14 days
             since being marked as stale.'


### PR DESCRIPTION
This pull request updates the `.github/workflows/close-inactive-issues.yml` file to improve the handling of stale issues by introducing an exemption mechanism.

* [`.github/workflows/close-inactive-issues.yml`](diffhunk://#diff-10a570b9ce6d1839f44f068037d9f5a1b80b124a7760ba20429e2f8beb774de3R21): Added `exempt-issue-labels` configuration to prevent issues labeled with 'not-stale' from being marked as stale.