### PR TITLE
Add OpenTelemetry collector configuration for CI testing

### DIFF
--- a/.github/configs/otel-collector-config.yaml
+++ b/.github/configs/otel-collector-config.yaml
@@ -1,0 +1,50 @@
+# OpenTelemetry Collector Configuration for CI Testing
+receivers:
+  # OTLP receiver accepts metrics and traces via gRPC and HTTP protocols
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+    sampling_initial: 2
+    sampling_thereafter: 500
+
+  # File exporter for traces only
+  file/traces:
+    path: /collector-logs/traces.json
+    format: json
+
+  # File exporter for metrics only
+  file/metrics:
+    path: /collector-logs/metrics.json
+    format: json
+
+extensions:
+  # Health check extension to monitor collector's health status for CI
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  # Telemetry configuration for collector's own logs (internal logging)
+  telemetry:
+    logs:
+      level: debug
+      encoding: json
+      output_paths: ['/collector-logs/collector-logs.json']
+
+  # Enable extensions
+  extensions: [health_check]
+
+  # Processing pipelines define data flow from receivers through processors to exporters
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [debug, file/traces]
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [debug, file/metrics]


### PR DESCRIPTION
## Summary

- Add `.github/configs/otel-collector-config.yaml` configuration for test workflows

## Details

This configuration file sets up an OpenTelemetry collector specifically for CI testing purposes:

**Receiver Configuration:**
- OTLP HTTP receiver on port 4318 for accepting telemetry data from the GitHub Action

**Exporter Configuration:**
- Debug exporter with detailed verbosity for troubleshooting
- Separate file exporters for traces (`/collector-logs/traces.json`) and metrics (`/collector-logs/metrics.json`)
- JSON format output for easy validation and comparison

**Health Check:**
- Health check endpoint on port 13133 for container readiness validation

**Service Configuration:**
- Debug-level logging with JSON output to `/collector-logs/collector-logs.json`
- Separate pipelines for traces and metrics processing

This configuration is used by the `validate-action-output.yml` workflow to collect and validate telemetry data generated by the GitHub Action.

## Test Plan

- [x] YAML syntax is valid
- [x] Receiver configuration accepts OTLP HTTP on correct port
- [x] Exporters write to appropriate file paths
- [x] Health check endpoint is properly configured
- [x] Pipelines route data from receivers to exporters correctly

🤖 Generated with [Claude Code](https://claude.ai/code)