### PR TITLE
Remove 'main' branch from workflow triggers in example workflows and …

### DIFF
--- a/.github/test-data/workflow-run-tests/metrics-expected.json
+++ b/.github/test-data/workflow-run-tests/metrics-expected.json
@@ -1,0 +1,251 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "github-actions-opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.29.0"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "github-actions-metrics"
+          },
+          "metrics": [
+            {
+              "name": "github.workflow.duration",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "github.job.duration",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Test Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Build Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Deploy Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "github.job.queued_duration",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Test Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Build Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Deploy Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.github/test-data/workflow-run-tests/traces-expected.json
+++ b/.github/test-data/workflow-run-tests/traces-expected.json
@@ -1,0 +1,485 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "github-actions-opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.30.1"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "github-actions-opentelemetry"
+          },
+          "spans": [
+            {
+              "name": "Example Workflow 01",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "repository",
+                  "value": {
+                    "stringValue": "paper2/github-actions-opentelemetry"
+                  }
+                },
+                {
+                  "key": "run_id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "run_attempt",
+                  "value": {
+                    "intValue": "1"
+                  }
+                },
+                {
+                  "key": "url",
+                  "value": {
+                    "stringValue": "https://example.com/actions/runs/0"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Example Application Pipeline / Test Application with time of waiting runner",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "waiting runner for Example Application Pipeline / Test Application",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Example Application Pipeline / Test Application",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Set up job",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Checkout",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Setup",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Install Dependencies",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Lint",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Test",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Complete job",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Example Application Pipeline / Build Application with time of waiting runner",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "waiting runner for Example Application Pipeline / Build Application",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Example Application Pipeline / Build Application",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Set up job",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Checkout",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Setup",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Install Dependencies",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Build",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Complete job",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Example Application Pipeline / Deploy Application with time of waiting runner",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "waiting runner for Example Application Pipeline / Deploy Application",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Example Application Pipeline / Deploy Application",
+              "kind": 1,
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Set up job",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Deploy",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            },
+            {
+              "name": "Complete job",
+              "kind": 1,
+              "status": {
+                "code": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/example-workflow-02.yml
+++ b/.github/workflows/example-workflow-02.yml
@@ -3,7 +3,6 @@ name: Example Workflow 02
 on:
   push:
     branches:
-      - main
       - getting-started
 
 jobs:

--- a/.github/workflows/example-workflow-03.yml
+++ b/.github/workflows/example-workflow-03.yml
@@ -3,7 +3,6 @@ name: Example Workflow 03
 on:
   push:
     branches:
-      - main
       - getting-started
 
 jobs:

--- a/.github/workflows/workflow-run-tests.yml
+++ b/.github/workflows/workflow-run-tests.yml
@@ -6,8 +6,6 @@ on:
   workflow_run:
     workflows:
       - Example Workflow 01
-      - Example Workflow 02
-      - Example Workflow 03
     types:
       - completed
 


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflows and test data. The updates include adjustments to branch triggers in workflows, removal of specific workflows from dependency checks, and the addition of expected metrics for OpenTelemetry instrumentation.

### Workflow adjustments:

* [`.github/workflows/example-workflow-02.yml`](diffhunk://#diff-4cac0c062f453a81e403fbc19afd9e734058550957e097afc4af2c5aec228c5bL6): Removed the `main` branch from the trigger list, leaving only the `getting-started` branch.
* [`.github/workflows/example-workflow-03.yml`](diffhunk://#diff-92ffd3d80425ac946daf2a58958e1ba569679cf40a81a660a3402cdc9f8727caL6): Removed the `main` branch from the trigger list, leaving only the `getting-started` branch.
* [`.github/workflows/workflow-run-tests.yml`](diffhunk://#diff-d215f3aec9fdc55bbb94c911ae36e423f2c994ebbce158d4f7f0034c6bd0668dL9-L10): Removed `Example Workflow 02` and `Example Workflow 03` from the list of dependent workflows.

### Test data updates:

* [`.github/test-data/workflow-run-tests/metrics-expected.json`](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7R1-R251): Added expected metrics for OpenTelemetry instrumentation, including workflow and job durations, queued durations, and associated attributes such as workflow name, repository, job name, and job conclusion.