### PR TITLE
Refactor expected metrics and traces JSON files to standardize struct…

### DIFF
--- a/.github/test-data/workflow-run-tests/metrics-expected.json
+++ b/.github/test-data/workflow-run-tests/metrics-expected.json
@@ -31,16 +31,39 @@
       },
       "scopeMetrics": [
         {
-          "scope": {
-            "name": "github-actions-metrics"
-          },
           "metrics": [
             {
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  }
+                ]
+              },
               "name": "github.workflow.duration",
-              "unit": "s",
+              "unit": "s"
+            },
+            {
               "gauge": {
                 "dataPoints": [
                   {
+                    "asDouble": 0,
                     "attributes": [
                       {
                         "key": "workflow.name",
@@ -53,138 +76,95 @@
                         "value": {
                           "stringValue": "paper2/github-actions-opentelemetry"
                         }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Build Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
                       }
-                    ]
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Test Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Deploy Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
                   }
                 ]
-              }
-            },
-            {
+              },
               "name": "github.job.duration",
-              "unit": "s",
-              "gauge": {
-                "dataPoints": [
-                  {
-                    "attributes": [
-                      {
-                        "key": "workflow.name",
-                        "value": {
-                          "stringValue": "Example Workflow 01"
-                        }
-                      },
-                      {
-                        "key": "repository",
-                        "value": {
-                          "stringValue": "paper2/github-actions-opentelemetry"
-                        }
-                      },
-                      {
-                        "key": "job.name",
-                        "value": {
-                          "stringValue": "Example Application Pipeline / Test Application"
-                        }
-                      },
-                      {
-                        "key": "job.conclusion",
-                        "value": {
-                          "stringValue": "success"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "attributes": [
-                      {
-                        "key": "workflow.name",
-                        "value": {
-                          "stringValue": "Example Workflow 01"
-                        }
-                      },
-                      {
-                        "key": "repository",
-                        "value": {
-                          "stringValue": "paper2/github-actions-opentelemetry"
-                        }
-                      },
-                      {
-                        "key": "job.name",
-                        "value": {
-                          "stringValue": "Example Application Pipeline / Build Application"
-                        }
-                      },
-                      {
-                        "key": "job.conclusion",
-                        "value": {
-                          "stringValue": "success"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "attributes": [
-                      {
-                        "key": "workflow.name",
-                        "value": {
-                          "stringValue": "Example Workflow 01"
-                        }
-                      },
-                      {
-                        "key": "repository",
-                        "value": {
-                          "stringValue": "paper2/github-actions-opentelemetry"
-                        }
-                      },
-                      {
-                        "key": "job.name",
-                        "value": {
-                          "stringValue": "Example Application Pipeline / Deploy Application"
-                        }
-                      },
-                      {
-                        "key": "job.conclusion",
-                        "value": {
-                          "stringValue": "success"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
+              "unit": "s"
             },
             {
-              "name": "github.job.queued_duration",
-              "unit": "s",
               "gauge": {
                 "dataPoints": [
                   {
-                    "attributes": [
-                      {
-                        "key": "workflow.name",
-                        "value": {
-                          "stringValue": "Example Workflow 01"
-                        }
-                      },
-                      {
-                        "key": "repository",
-                        "value": {
-                          "stringValue": "paper2/github-actions-opentelemetry"
-                        }
-                      },
-                      {
-                        "key": "job.name",
-                        "value": {
-                          "stringValue": "Example Application Pipeline / Test Application"
-                        }
-                      },
-                      {
-                        "key": "job.conclusion",
-                        "value": {
-                          "stringValue": "success"
-                        }
-                      }
-                    ]
-                  },
-                  {
+                    "asDouble": 0,
                     "attributes": [
                       {
                         "key": "workflow.name",
@@ -210,9 +190,43 @@
                           "stringValue": "success"
                         }
                       }
-                    ]
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
                   },
                   {
+                    "asDouble": 0,
+                    "attributes": [
+                      {
+                        "key": "workflow.name",
+                        "value": {
+                          "stringValue": "Example Workflow 01"
+                        }
+                      },
+                      {
+                        "key": "repository",
+                        "value": {
+                          "stringValue": "paper2/github-actions-opentelemetry"
+                        }
+                      },
+                      {
+                        "key": "job.name",
+                        "value": {
+                          "stringValue": "Example Application Pipeline / Test Application"
+                        }
+                      },
+                      {
+                        "key": "job.conclusion",
+                        "value": {
+                          "stringValue": "success"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
+                  },
+                  {
+                    "asDouble": 0,
                     "attributes": [
                       {
                         "key": "workflow.name",
@@ -238,12 +252,19 @@
                           "stringValue": "success"
                         }
                       }
-                    ]
+                    ],
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0"
                   }
                 ]
-              }
+              },
+              "name": "github.job.queued_duration",
+              "unit": "s"
             }
-          ]
+          ],
+          "scope": {
+            "name": "github-actions-metrics"
+          }
         }
       ]
     }

--- a/.github/test-data/workflow-run-tests/traces-expected.json
+++ b/.github/test-data/workflow-run-tests/traces-expected.json
@@ -36,8 +36,6 @@
           },
           "spans": [
             {
-              "name": "Example Workflow 01",
-              "kind": 1,
               "attributes": [
                 {
                   "key": "repository",
@@ -64,13 +62,18 @@
                   }
                 }
               ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Example Workflow 01",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
-              "name": "Example Application Pipeline / Test Application with time of waiting runner",
-              "kind": 1,
               "attributes": [
                 {
                   "key": "job.id",
@@ -97,128 +100,18 @@
                   }
                 }
               ],
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "waiting runner for Example Application Pipeline / Test Application",
+              "endTimeUnixNano": "0",
               "kind": 1,
-              "attributes": [
-                {
-                  "key": "job.id",
-                  "value": {
-                    "intValue": "0"
-                  }
-                },
-                {
-                  "key": "job.conclusion",
-                  "value": {
-                    "stringValue": "success"
-                  }
-                },
-                {
-                  "key": "runner.name",
-                  "value": {
-                    "stringValue": "GitHub Actions 0"
-                  }
-                },
-                {
-                  "key": "runner.group",
-                  "value": {
-                    "stringValue": "GitHub Actions"
-                  }
-                }
-              ],
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Example Application Pipeline / Test Application",
-              "kind": 1,
-              "attributes": [
-                {
-                  "key": "job.id",
-                  "value": {
-                    "intValue": "0"
-                  }
-                },
-                {
-                  "key": "job.conclusion",
-                  "value": {
-                    "stringValue": "success"
-                  }
-                },
-                {
-                  "key": "runner.name",
-                  "value": {
-                    "stringValue": "GitHub Actions 0"
-                  }
-                },
-                {
-                  "key": "runner.group",
-                  "value": {
-                    "stringValue": "GitHub Actions"
-                  }
-                }
-              ],
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Set up job",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Checkout",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Setup",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Install Dependencies",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Lint",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Test",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
-              "name": "Complete job",
-              "kind": 1,
-              "status": {
-                "code": 1
-              }
-            },
-            {
               "name": "Example Application Pipeline / Build Application with time of waiting runner",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
               "attributes": [
                 {
                   "key": "job.id",
@@ -245,13 +138,18 @@
                   }
                 }
               ],
-              "status": {
-                "code": 1
-              }
-            },
-            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "waiting runner for Example Application Pipeline / Build Application",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
               "attributes": [
                 {
                   "key": "job.id",
@@ -278,88 +176,90 @@
                   }
                 }
               ],
-              "status": {
-                "code": 1
-              }
-            },
-            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Example Application Pipeline / Build Application",
-              "kind": 1,
-              "attributes": [
-                {
-                  "key": "job.id",
-                  "value": {
-                    "intValue": "0"
-                  }
-                },
-                {
-                  "key": "job.conclusion",
-                  "value": {
-                    "stringValue": "success"
-                  }
-                },
-                {
-                  "key": "runner.name",
-                  "value": {
-                    "stringValue": "GitHub Actions 0"
-                  }
-                },
-                {
-                  "key": "runner.group",
-                  "value": {
-                    "stringValue": "GitHub Actions"
-                  }
-                }
-              ],
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Set up job",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Checkout",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Setup",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Install Dependencies",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Build",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Complete job",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
-              "name": "Example Application Pipeline / Deploy Application with time of waiting runner",
-              "kind": 1,
               "attributes": [
                 {
                   "key": "job.id",
@@ -386,13 +286,18 @@
                   }
                 }
               ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Example Application Pipeline / Test Application with time of waiting runner",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
-              "name": "waiting runner for Example Application Pipeline / Deploy Application",
-              "kind": 1,
               "attributes": [
                 {
                   "key": "job.id",
@@ -419,13 +324,18 @@
                   }
                 }
               ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "waiting runner for Example Application Pipeline / Test Application",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
-              "name": "Example Application Pipeline / Deploy Application",
-              "kind": 1,
               "attributes": [
                 {
                   "key": "job.id",
@@ -452,30 +362,250 @@
                   }
                 }
               ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Example Application Pipeline / Test Application",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Set up job",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
-              "name": "Deploy",
+              "endTimeUnixNano": "0",
               "kind": 1,
+              "name": "Checkout",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
             },
             {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Setup",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Install Dependencies",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Lint",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Test",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
               "name": "Complete job",
-              "kind": 1,
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
               "status": {
                 "code": 1
-              }
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Example Application Pipeline / Deploy Application with time of waiting runner",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "waiting runner for Example Application Pipeline / Deploy Application",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "attributes": [
+                {
+                  "key": "job.id",
+                  "value": {
+                    "intValue": "0"
+                  }
+                },
+                {
+                  "key": "job.conclusion",
+                  "value": {
+                    "stringValue": "success"
+                  }
+                },
+                {
+                  "key": "runner.name",
+                  "value": {
+                    "stringValue": "GitHub Actions 0"
+                  }
+                },
+                {
+                  "key": "runner.group",
+                  "value": {
+                    "stringValue": "GitHub Actions"
+                  }
+                }
+              ],
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Example Application Pipeline / Deploy Application",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Set up job",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Deploy",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
+            },
+            {
+              "endTimeUnixNano": "0",
+              "kind": 1,
+              "name": "Complete job",
+              "parentSpanId": "0000000000000000",
+              "spanId": "0000000000000000",
+              "startTimeUnixNano": "0",
+              "status": {
+                "code": 1
+              },
+              "traceId": "00000000000000000000000000000000"
             }
           ]
         }


### PR DESCRIPTION
This pull request updates test data files for workflow run metrics and traces to include additional attributes and timestamps, and adjusts naming conventions for better consistency. Key changes involve adding `startTimeUnixNano` and `timeUnixNano` fields, modifying span names, and ensuring trace data includes comprehensive metadata.

### Updates to Metrics Test Data:

* Added `startTimeUnixNano` and `timeUnixNano` fields to data points in `.github/test-data/workflow-run-tests/metrics-expected.json` to include timestamps for metrics. [[1]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L57-R66) [[2]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L93-R97) [[3]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L121-R128) [[4]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L149-R167) [[5]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L241-L246)
* Adjusted job names to improve clarity, such as switching between "Build Application" and "Test Application" for specific metrics. [[1]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L84-R83) [[2]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L112-R114) [[3]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L176-R184) [[4]](diffhunk://#diff-5df1f0674451092a5216a6edad5bdb8eb31027e0a96dfba1b9c13ef4602eb8d7L204-R215)

### Updates to Traces Test Data:

* Added `startTimeUnixNano`, `endTimeUnixNano`, `spanId`, `parentSpanId`, and `traceId` fields to spans in `.github/test-data/workflow-run-tests/traces-expected.json` to enhance trace metadata. [[1]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R65-L73) [[2]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R103-L106) [[3]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R141-L139) [[4]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6L166-L221) [[5]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R289-L254)
* Updated span names for consistency, such as renaming spans to reflect specific job phases (e.g., "Build Application" vs. "Test Application"). [[1]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R141-L139) [[2]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R365-R460) [[3]](diffhunk://#diff-592e110747209a6060bf48c03f0be45aaf3350f8b9bd89f024320ae67049b6a6R487-L395)