### PR TITLE
release 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript-action",
-  "version": "v0.10.1",
+  "version": "v1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript-action",
-      "version": "v0.10.1",
+      "version": "v1.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-action",
   "description": "GitHub Actions TypeScript template",
-  "version": "v0.10.1",
+  "version": "v1.0.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/typescript-action",


### PR DESCRIPTION
## Summary
Bump package version to **v1.0.0** so `script/release` can tag the first 1.x release after the combined dependency updates in #211.

## Test plan
- [ ] CI green
- [ ] After merge, tag `v1.0.0` / `v1` and publish the GitHub release